### PR TITLE
#30 Convert mermaid resource path to a file URL for OS compatibility

### DIFF
--- a/content-provider.js
+++ b/content-provider.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const vscode = require('vscode');
 const _ = require('lodash');
+const fileUrl = require('file-url');
 
 const findDiagram = require('./find-diagram');
 
@@ -15,7 +16,7 @@ module.exports = class MermaidDocumentContentProvider {
 
     provideTextDocumentContent (uri, token) {
         const config = JSON.stringify(vscode.workspace.getConfiguration('mermaid'));
-        const base = this.context.asAbsolutePath('node_modules/mermaid/dist/mermaid');
+        const base = fileUrl(this.context.asAbsolutePath('node_modules/mermaid/dist/mermaid'));
 
         return `<!DOCTYPE html>
         <html>

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install"
   },
   "dependencies": {
+    "file-url": "^2.0.2",
     "lodash": "^4.17.4",
     "mermaid": "^7.0.0"
   },


### PR DESCRIPTION
Hi @vstirbu,
The changes to convert the mermaid resource path to a file URL via [file-url](https://www.npmjs.com/package/file-url) have been tested on Windows, OSX, and Linux.  It's looking good.  Thanks for your support.
