### PR TITLE
Support for standalone Mermaid files

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ sequenceDiagram
 ```
 </pre>
 
+### Standalone Mermaid files
+
+Files with extension ``.mmd`` with plain Mermaid diagram content:
+
+```
+sequenceDiagram
+  A-->B: Works!
+```
+
 ## Customize diagrams
 
 You can customize the appearence of the previewed diagrams by setting the mermaid configuration in the workspace settings:
@@ -55,4 +64,4 @@ You can customize the appearence of the previewed diagrams by setting the mermai
 }
 ```
 
-All mermaid configuration [options](http://knsv.github.io/mermaid/#mermaidapi) are supported. 
+All mermaid configuration [options](http://knsv.github.io/mermaid/#mermaidapi) are supported.

--- a/content-provider.js
+++ b/content-provider.js
@@ -65,7 +65,9 @@ module.exports = class MermaidDocumentContentProvider {
     const text = editor.document.getText();
     const selStart = editor.document.offsetAt(editor.selection.anchor);
 
-    const graph = findDiagram(text, selStart);
+    const graph = /\.mmd$/.test(editor.document.fileName)
+      ? text
+      : findDiagram(text, selStart);
 
     if (graph) {
       this.graph = graph;


### PR DESCRIPTION
Allows previewing plain Mermaid diagram files with `.mmd` extension.

Standalone `.mmd` files could be used eg. with Mermaid CLI:
https://github.com/mermaidjs/mermaid.cli#examples