### PR TITLE
Update markdown regex for azuredevops

### DIFF
--- a/lib/find-diagram.js
+++ b/lib/find-diagram.js
@@ -33,7 +33,7 @@ function findDiagram(text, cursor) {
   const re = {
     html: /<div class="mermaid">([\s\S]*?)<\/div>/g,
     hugo: /\{\{<mermaid.*>\}\}([\s\S]*?)\{\{<\/mermaid>\}\}/g,
-    markdown: /```mermaid([\s\S]*?)```/g,
+    markdown: /```mermaid([\s\S]*?)```|:::mermaid([\s\S]*?):::/g,
     sphinx: /\.\. mermaid::(?:[ \t]*)?$(?:(?:\n[ \t]+:(?:(?:\\:\s)|[^:])+:[^\n]*$)+\n)?((?:\n(?:[ \t][^\n]*)?$)+)?/gm
   };
 


### PR DESCRIPTION
Azure Devops only recognises. e.g.
<pre>
:::mermaid
sequenceDiagram
  A-->B: Works!
:::
</pre>
as its definition for mermaid diagrams.
This update allows the the plugin to recognise both.

Doc: https://docs.microsoft.com/en-us/azure/devops/project/wiki/wiki-markdown-guidance?view=azure-devops#add-mermaid-diagrams-to-a-wiki-page