### PR TITLE
Fix Markdown and VSTS regex

### DIFF
--- a/lib/find-diagram.js
+++ b/lib/find-diagram.js
@@ -33,14 +33,16 @@ function findDiagram(text, cursor) {
   const re = {
     html: /<div class="mermaid">([\s\S]*?)<\/div>/g,
     hugo: /\{\{<mermaid.*>\}\}([\s\S]*?)\{\{<\/mermaid>\}\}/g,
+    markdown: /```mermaid([\s\S]*?)```/g,
     // the whitespace between ::: and mermaid is for Azure DevOps Wiki
-    markdown: /```mermaid([\s\S]*?)```|::: ?mermaid([\s\S]*?):::/g,
+    vsts: /::: ?mermaid([\s\S]*?):::/g,
     sphinx: /\.\. mermaid::(?:[ \t]*)?$(?:(?:\n[ \t]+:(?:(?:\\:\s)|[^:])+:[^\n]*$)+\n)?((?:\n(?:[ \t][^\n]*)?$)+)?/gm
   };
 
   return (
     findDiagramWithRegExp(re.html, text, cursor) ||
     findDiagramWithRegExp(re.markdown, text, cursor) ||
+    findDiagramWithRegExp(re.vsts, text, cursor) ||
     findDiagramWithRegExp(re.hugo, text, cursor) ||
     findDiagramWithRegExp(re.sphinx, text, cursor)
   );


### PR DESCRIPTION
Since findDiagramWithRegExp always checks the first capture group, the
regex for markdown and vsts are separated to make both work. This is
tested locally in VS Code 1.43.2